### PR TITLE
Prevent premium plugins from being added to queue

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -102,7 +102,7 @@ async function getSpigotVersions(resourceId: number): Promise<any[]> {
 async function searchSpigot(query: string): Promise<Plugin[]> {
   try {
     const response = await fetch(
-      `https://api.spiget.org/v2/search/resources/${encodeURIComponent(query)}?size=10&sort=-downloads&fields=id,name,tag,author,testedVersions,downloads`
+      `https://api.spiget.org/v2/search/resources/${encodeURIComponent(query)}?size=10&sort=-downloads&fields=id,name,tag,author,testedVersions,downloads,premium`
     )
     const results = await response.json()
 
@@ -113,6 +113,8 @@ async function searchSpigot(query: string): Promise<Plugin[]> {
           const details = await detailsResponse.json()
           
           const versions = await getSpigotVersions(result.id)
+
+          console.log(result)
           
           return {
             id: `spigot-${result.id}`,
@@ -122,7 +124,8 @@ async function searchSpigot(query: string): Promise<Plugin[]> {
             downloads: result.downloads,
             provider: 'spigot',
             resourceUrl: `https://www.spigotmc.org/resources/${result.id}`,
-            versions: versions
+            versions: versions,
+            premium: result.premium
           }
         } catch (error) {
           console.error(`Error processing Spigot plugin ${result.id}:`, error)

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -114,8 +114,6 @@ async function searchSpigot(query: string): Promise<Plugin[]> {
           
           const versions = await getSpigotVersions(result.id)
 
-          console.log(result)
-          
           return {
             id: `spigot-${result.id}`,
             name: result.name,

--- a/src/components/PluginCard.tsx
+++ b/src/components/PluginCard.tsx
@@ -25,6 +25,9 @@ export default function PluginCard({ plugin, showActions = true }: PluginCardPro
   const [error, setError] = useState<string | null>(null)
   const isInQueue = isSaved(plugin.id)
 
+  console.log(plugin.name)
+  console.log(plugin.premium)
+
   useEffect(() => {
     const fetchVersions = async () => {
       try {
@@ -140,15 +143,25 @@ export default function PluginCard({ plugin, showActions = true }: PluginCardPro
                   Remove
                 </button>
               ) : (
-                <button
-                  onClick={handleAddToQueue}
-                  className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-md text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/30 transition-colors"
-                  disabled={!selectedVersion}
-                >
-                  <PlusIcon className="h-4 w-4" />
-                  Add to Queue
-                </button>
-              )}
+                !plugin.premium ? (
+                  <button
+                      onClick={handleAddToQueue}
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-md text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/30 transition-colors"
+                      disabled={!selectedVersion}
+                  >
+                    <PlusIcon className="h-4 w-4" />
+                    Add to Queue
+                  </button>
+                ) : (
+                  <button
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-md text-red-700 dark:text-red-400 transition-colors"
+                      disabled
+                      title="This is a premium plugin and cannot be added to the queue. Please download it from the original site."
+                  >
+                    Premium Plugin
+                  </button>
+                )
+            )}
             </div>
           )}
         </div>

--- a/src/components/PluginCard.tsx
+++ b/src/components/PluginCard.tsx
@@ -25,9 +25,6 @@ export default function PluginCard({ plugin, showActions = true }: PluginCardPro
   const [error, setError] = useState<string | null>(null)
   const isInQueue = isSaved(plugin.id)
 
-  console.log(plugin.name)
-  console.log(plugin.premium)
-
   useEffect(() => {
     const fetchVersions = async () => {
       try {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -7,6 +7,7 @@ export interface Plugin {
   downloads: number
   provider: PluginProvider
   url: string
+  premium: boolean
 }
 
 export interface SavedPlugin extends Plugin {


### PR DESCRIPTION
This PR ensures that people cannot add any premium plugins to the download queue, as they won't get downloaded anyway. They will still appear in the queue, but the button will be disabled. (for spigot)

<img width="1398" alt="image" src="https://github.com/user-attachments/assets/9371a3da-ab27-4468-81fd-a949239c8f40">

## Summary by Sourcery

Enhancements:
- Add a check to prevent premium plugins from being added to the download queue.